### PR TITLE
Run action on Node16

### DIFF
--- a/.github/templates/jobs/build.erb
+++ b/.github/templates/jobs/build.erb
@@ -1,7 +1,7 @@
 build:
   runs-on: <%= ubuntu_version %>
   steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
   - name: Set Node.js 12.x
     uses: actions/setup-node@v2
     with:

--- a/.github/templates/jobs/test.erb
+++ b/.github/templates/jobs/test.erb
@@ -1,11 +1,11 @@
 test:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v2
-    - name: Set Node.js 12.x
+    - uses: actions/checkout@v3
+    - name: Set Node.js 16.x
       uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: 16.x
     - name: "Build action for test"
       run: |
         npm ci

--- a/.github/templates/release.yml.erb
+++ b/.github/templates/release.yml.erb
@@ -14,7 +14,7 @@ jobs:
     name: "Build and release action"
     needs: [build, test]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/pull_request.generated.yml
+++ b/.github/workflows/pull_request.generated.yml
@@ -15,11 +15,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Set Node.js 12.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: "Install"
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@v3
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: "Build action for test"
         run: |
           npm ci

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -15,11 +15,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Set Node.js 12.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: "Install"
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@v3
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: "Build action for test"
         run: |
           npm ci
@@ -66,7 +66,7 @@ jobs:
           EXPECTED_BUNDLE_SIZE: '89501'
 
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: "Build and release action"
     needs: [build, test]
     steps:
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
       - name: Set Node.js 12.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
       - name: Configure git

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Your name here'
-description: 'Provide a description here'
-author: 'Your name or organization here'
+name: "HTML Bundle Size"
+description: "Calculate the total size of a HTML bundle's assets"
+author: "Smartly.io Solutions Oy"
 inputs:
   path:
     required: true

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ outputs:
   size:
     description: "Size in bytes of the full build bundle"
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Latest GitHub Actions uses Node16 as default. This is the default for GitHub's own actions like setup-node.

This is technically a breaking change if the GitHub Actions runner image is not updated.